### PR TITLE
Add -reload-every flag (XQAPI_RELOAD_EVERY)

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -43,6 +43,11 @@ It loads repodata into memory prior to serving it.
     complete.
     Defaults to `16`.
 
+`-reload-every`=_{duration}_::
+    Reload repository data every _duration_. If the duration is zero or a
+    negative interval, automatic reloading is disabled. By default, automatic
+    reloading is disabled.
+
 `-log-access`=_{t|f}_::
     Whether to emit access logs. Requests that get a 404, 304, or 0 response are
     not logged. If passed without a value, `t` is assumed.

--- a/env.go
+++ b/env.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"strconv"
+	"time"
 )
 
 // etoi looks up an environment variable by name and, if defined, parses it as an integer, and
@@ -47,4 +48,20 @@ func etos(name, def string) string {
 		return def
 	}
 	return v
+}
+
+// etod looks up an environment variable and, if defined, parses it as a duration and returns the
+// parsed duration. If the environment variable isn't defined or cannot be parsed, it returns def.
+//
+// Valid duration strings are those supported by time.ParseDuration.
+func etod(name string, def time.Duration) time.Duration {
+	v, ok := os.LookupEnv(name)
+	if !ok {
+		return def
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return def
+	}
+	return d
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module go.spiff.io/xq-api
 
-go 1.13
+go 1.15
 
 require (
 	github.com/NYTimes/gziphandler v1.0.1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,20 +1,30 @@
 # github.com/NYTimes/gziphandler v1.0.1
+## explicit
 github.com/NYTimes/gziphandler
 # github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+## explicit
 github.com/golang/glog
 # github.com/gorilla/handlers v1.4.0
+## explicit
 github.com/gorilla/handlers
 # github.com/julienschmidt/httprouter v1.2.0
+## explicit
 github.com/julienschmidt/httprouter
 # github.com/klauspost/compress v1.10.2
+## explicit
 github.com/klauspost/compress/fse
 github.com/klauspost/compress/huff0
 github.com/klauspost/compress/snappy
 github.com/klauspost/compress/zstd
 github.com/klauspost/compress/zstd/internal/xxhash
+# github.com/stretchr/testify v1.3.0
+## explicit
 # golang.org/x/sys v0.0.0-20190109145017-48ac38b7c8cb
+## explicit
 golang.org/x/sys/unix
 # golang.org/x/tools v0.0.0-20190110211028-68c5ac90f574
+## explicit
 golang.org/x/tools/container/intsets
 # howett.net/plist v0.0.0-20181124034731-591f970eefbb
+## explicit
 howett.net/plist

--- a/xq-api.8
+++ b/xq-api.8
@@ -2,12 +2,12 @@
 .\"     Title: xq-api
 .\"    Author: Noel Cower
 .\" Generator: Asciidoctor 1.5.8
-.\"      Date: 2019-01-20
+.\"      Date: 2021-02-27
 .\"    Manual: XQ-API
 .\"    Source: XQ-API
 .\"  Language: English
 .\"
-.TH "XQ\-API" "8" "2019-01-20" "XQ\-API" "XQ\-API"
+.TH "XQ\-API" "8" "2021-02-27" "XQ\-API" "XQ\-API"
 .ie \n(.g .ds Aq \(aq
 .el       .ds Aq '
 .ss \n[.ss] 0
@@ -64,6 +64,13 @@ The maximum number of query requests that can run in parallel. If more than
 \f(CRn\fP query requests are made in parallel, they will block until others
 complete.
 Defaults to \f(CR16\fP.
+.RE
+.sp
+\f(CR\-reload\-every\fP=\fI{duration}\fP
+.RS 4
+Reload repository data every \fIduration\fP. If the duration is zero or a
+negative interval, automatic reloading is disabled. By default, automatic
+reloading is disabled.
 .RE
 .sp
 \f(CR\-log\-access\fP=\fI{t|f}\fP


### PR DESCRIPTION
Add a -reload-every flag to reload the xq-api's repodata on a fixed
interval. By default, this is disabled. The value of the flag can be
set by setting the XQAPI_RELOAD_EVERY environment variable.

The logic for reloading on HUP has been moved down to the
reloadOnSignal function, to keep the triggered reload logic out of the
main function. Figured that now that there's two cases of it, it would
be best to get that out of the way now.